### PR TITLE
Fixes #23

### DIFF
--- a/src/queryParser.js
+++ b/src/queryParser.js
@@ -8,7 +8,7 @@ export function parseQuery (query) {
     const orderBy = query.orderBy || query.sort
     if (Array.isArray(orderBy)) {
       query.orderBy = orderBy.map((clause) => {
-        if (typeof clause === 'string') {
+        if (typeof clause === 'string' && clause.indexOf('{') >= 0) {
           return JSON.parse(clause)
         }
         return clause

--- a/src/queryParser.js
+++ b/src/queryParser.js
@@ -6,15 +6,15 @@ export function parseQuery (query) {
   }
   if (query.orderBy || query.sort) {
     const orderBy = query.orderBy || query.sort
-    if (orderBy.length) {
+    if (Array.isArray(orderBy)) {
       query.orderBy = orderBy.map((clause) => {
         if (typeof clause === 'string') {
           return JSON.parse(clause)
         }
         return clause
       })
-      query.sort = undefined
     }
+    query.sort = undefined
   }
 }
 

--- a/test/queryParser.test.js
+++ b/test/queryParser.test.js
@@ -170,4 +170,3 @@ describe('queryParser', function () {
   it('should parse offset')
   it('should parse with')
 })
-

--- a/test/queryParser.test.js
+++ b/test/queryParser.test.js
@@ -91,6 +91,28 @@ describe('queryParser', function () {
     })
   })
 
+  it('should use orderBy directly if orderBy is present as simple string', function () {
+    const query = {
+      orderBy: 'foo'
+    }
+    JSDataExpress.parseQuery(query)
+    assert.deepEqual(query, {
+      orderBy: 'foo',
+      sort: undefined
+    })
+  })
+
+  it('should use orderBy directly if orderBy is present as array of strings', function () {
+    const query = {
+      orderBy: ['foo']
+    }
+    JSDataExpress.parseQuery(query)
+    assert.deepEqual(query, {
+      orderBy: ['foo'],
+      sort: undefined
+    })
+  })
+
   it('should not parse orderBy if orderby is present but is empty', function () {
     const query = {
       orderBy: []
@@ -148,3 +170,4 @@ describe('queryParser', function () {
   it('should parse offset')
   it('should parse with')
 })
+


### PR DESCRIPTION
Fixes #23

- [x] - `npm test` succeeds
- [x] - Code coverage does not decrease (if any source code was changed)