### PR TITLE
build(): change node version for circleci

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE files
+.idea/
+
 dist/*.js
 dist/*.map
 

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ general:
       - gh-pages
 machine:
   node:
-    version: 5.7.0
+    version: 5.11.0
 dependencies:
   pre:
     - npm i -g npm

--- a/circle.yml
+++ b/circle.yml
@@ -4,12 +4,12 @@ general:
       - gh-pages
 machine:
   node:
-    version: 5.11.0
+    version: 6
 dependencies:
   pre:
     - npm i -g npm
     - npm i -g codecov nyc
-    - npm i js-data@^3.0.0-rc.4 express
+    - npm i js-data@^3.0.1 express
 test:
   post:
     - nyc report --reporter=lcov | codecov


### PR DESCRIPTION
circle ci builds are failing because of the node version 5.7
